### PR TITLE
Extended library with ignoreList parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,110 @@ To:
 }
 ```
 
-##Usage
+##How to use
+
+
+To use this library you first need to include it.
+```javascript
+var dirTree = require('directory-tree');
+```
+
+After that you can turn every directory tree in a json object.
 
 ```javascript
 var dirTree = require('directory-tree');
-var tree = dirTree.directoryTree('/some/path');
+
+// Get full directory tree
+var tree = dirTree.directoryTree('/photos');
+
+// Only get the structure which contains *.jpg or *.png files.
+var filteredTree = dirTree.directoryTree('/photos',  {'fileTypes': ['.jpg', '.png']} );
+
+// Remove the 'winter' direcory from the result
+var filteredTree = dirTree.directoryTree('/photos',  {'ignoreList': ['winter']} );
 ```
 
-And you can also filter by extensions:
+##Options
+
+###fileTypes 
+Using the `fileTypes` parameter you can narrow the found results by only including files with a certain filetype. The files you want to look for are given as an array.
+
+*example:*
 
 ```javascript
-var dirTree = require('directory-tree');
-var filteredTree = dirTree.directoryTree('/some/path', ['.jpg', '.png']);
-```
+var jsFilesTree = dirTree.directoryTree('/photos', {'fileTypes': ['.png']});
+
+/*
+{
+  "path": "",
+  "name": "photos",
+  "type": "directory",
+  "children": [
+    {
+      "path": "winter",
+      "name": "winter",
+      "type": "directory",
+      "children": [
+        {
+          "path": "winter/january",
+          "name": "january",
+          "type": "directory",
+          "children": [
+            {
+              "path": "winter/january/ski.png",
+              "name": "ski.png",
+              "type": "file"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+
+ */
+
+```   
+
+
+###ignoreList 
+Using the `ignoreList` paramater you can exclude (ignore) certain files and/or directories from the result.
+
+*example:*
+
+```javascript
+var jsFilesTree = dirTree.directoryTree('/photos', {'ignoreList': ['winter']});
+
+/*
+{
+  "path": "",
+  "name": "photos",
+  "type": "directory",
+  "children": [
+    {
+      "path": "summer",
+      "name": "summer",
+      "type": "directory",
+      "children": [
+        {
+          "path": "summer/june",
+          "name": "june",
+          "type": "directory",
+          "children": [
+            {
+              "path": "summer/june/windsurf.jpg",
+              "name": "windsurf.jpg",
+              "type": "file"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+ */
+```   
+
+

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -24,14 +24,15 @@ searchSubstring = function(string, array){
 }
 
 
-function directoryTree(basepath, extensions, ignoreList) {
+function directoryTree(basepath, options) {
 
-    var _directoryTree = function (name, extensions, ignoreList) {
+    var _directoryTree = function (name, options) {
+
 
         var ignore = false;
-        if ( typeof ignoreList === "object") {
+        if ( typeof options.ignoreList === "object") {
             // // Check if the name (file | directory) is on the ignore list
-            if ( searchSubstring(name, ignoreList) ) {
+            if ( searchSubstring(name, options.ignoreList) ) {
                 ignore = true;
             }
         }
@@ -44,16 +45,16 @@ function directoryTree(basepath, extensions, ignoreList) {
             };
 
             if (stats.isFile()) {
-                if (extensions &&
-                    extensions.length > 0 &&
-                    extensions.indexOf(path.extname(name).toLowerCase()) == -1) {
+                if (options.extensions &&
+                    options.extensions.length > 0 &&
+                    options.extensions.indexOf(path.extname(name).toLowerCase()) == -1) {
                     return null;
                 }
                 item.type = 'file';
             } else {
                 item.type = 'directory';
                 item.children = fs.readdirSync(name).map(function (child) {
-                    return _directoryTree(path.join(name, child), extensions, ignoreList);
+                    return _directoryTree(path.join(name, child), options);
                 }).filter(function (e) {
                     return e != null;
                 });
@@ -67,7 +68,7 @@ function directoryTree(basepath, extensions, ignoreList) {
 
         return item;
     }
-    return _directoryTree(basepath, extensions, ignoreList);
+    return _directoryTree(basepath, options);
 }
 
 

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -1,38 +1,76 @@
 var fs = require('fs');
 var path = require('path');
 
-function directoryTree(basepath, extensions) {
-    var _directoryTree = function (name, extensions) {
-        var stats = fs.statSync(name);
-        var item = {
-            path: path.relative(basepath, name),
-            name: path.basename(name)
-        };
+/**
+ * Looks if any if array values is found in the given string.
+ *     ex.
+ *     array  = ['asdf', 1, 'test.js']
+ *     string = 'this/is/the/test/string.js' // expected return: false
+ *     string = 'this/is/a/test.js' // expected return: true
+*
+ * @param  {string} string  The haystack which you want to search through
+ * @param  {array} array    The needles which you are looking for
+ * @return {boolean}        True if a needle is found, otherwise false.
+ */
+searchSubstring = function(string, array){
+    var found = false;
+    array.forEach( function(value, key){
+        if (string.indexOf( value ) > 0 ) {
+            found = true;
+            return true;
+        }
+    })
+    return found;
+}
 
-        if (stats.isFile()) {
-            if (extensions &&
-                extensions.length > 0 &&
-                extensions.indexOf(path.extname(name).toLowerCase()) == -1) {
-                return null;
+
+function directoryTree(basepath, extensions, ignoreList) {
+
+    var _directoryTree = function (name, extensions, ignoreList) {
+
+        var ignore = false;
+        if ( typeof ignoreList === "object") {
+            // // Check if the name (file | directory) is on the ignore list
+            if ( searchSubstring(name, ignoreList) ) {
+                ignore = true;
             }
-            item.type = 'file';
-        } else {
-            item.type = 'directory';
-            item.children = fs.readdirSync(name).map(function (child) {
-                return _directoryTree(path.join(name, child), extensions);
-            }).filter(function (e) {
-                return e != null;
-            });
+        }
+        if (!ignore) {
 
-            if (item.children.length == 0) {
-                return null;
+            var stats = fs.statSync(name);
+            var item = {
+                path: path.relative(basepath, name),
+                name: path.basename(name)
+            };
+
+            if (stats.isFile()) {
+                if (extensions &&
+                    extensions.length > 0 &&
+                    extensions.indexOf(path.extname(name).toLowerCase()) == -1) {
+                    return null;
+                }
+                item.type = 'file';
+            } else {
+                item.type = 'directory';
+                item.children = fs.readdirSync(name).map(function (child) {
+                    return _directoryTree(path.join(name, child), extensions, ignoreList);
+                }).filter(function (e) {
+                    return e != null;
+                });
+
+
+                if (item.children.length == 0) {
+                    return null;
+                }
             }
         }
 
         return item;
     }
-    return _directoryTree(basepath, extensions);
+    return _directoryTree(basepath, extensions, ignoreList);
 }
 
+
 exports.directoryTree = directoryTree;
+
 


### PR DESCRIPTION
For a brainfart I'm working on, I would like to iterate through a directory to search for *.js files. This lib is great for using that. But I wanted too exclude certain directories (like the 'node_modules' dir for example). This is why I extended the library with an option 'ignoreList'. This parameter can contain an array with files or directories which should be excluded from the result json object.

If you like this feature you could add it to the main branch, otherwise just reject it. No hard feelings ;-)