### PR TITLE
multiple updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
-  - "iojs-v1.0.4"
+  - "4.2"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,30 @@
 
 #directory-tree
 
-Creates an object representing a directory tree.
+Creates an javascript object representing a directory tree.
 
-From:
+## Install
+```js
+npm i -S directory-tree
+
+```
+
+
+##Usage
+
+```js
+var dirTree = require('directory-tree');
+var tree = dirTree('/some/path');
+```
+
+And you can also filter by extensions:
+
+```js
+var dirTree = require('directory-tree');
+var filteredTree = dirTree('/some/path', ['.jpg', '.png']);
+```
+
+This will take a directory tree:
 
 ```
 photos
@@ -17,60 +38,52 @@ photos
         └── snowboard.jpg
 ```
 
-To:
+And return a js object:
 
 ```json
 {
-  "path": "",
+  "path": "photos",
   "name": "photos",
   "size": 600,
-  "type": "directory",
   "children": [
     {
-      "path": "summer",
+      "path": "photos/summer",
       "name": "summer",
       "size": 400,
-      "type": "directory",
       "children": [
         {
-          "path": "summer/june",
+          "path": "photos/summer/june",
           "name": "june",
           "size": 400,
-          "type": "directory",
           "children": [
             {
-              "path": "summer/june/windsurf.jpg",
+              "path": "photos/summer/june/windsurf.jpg",
               "size": 400,
               "name": "windsurf.jpg",
-              "type": "file"
             }
           ]
         }
       ]
     },
     {
-      "path": "winter",
+      "path": "photos/winter",
       "name": "winter",
       "size": 200,
-      "type": "directory",
       "children": [
         {
-          "path": "winter/january",
+          "path": "photos/winter/january",
           "name": "january",
           "size": 200,
-          "type": "directory",
           "children": [
             {
-              "path": "winter/january/ski.png",
+              "path": "photos/winter/january/ski.png",
               "name": "ski.png",
               "size": 100,
-              "type": "file"
             },
             {
-              "path": "winter/january/snowboard.jpg",
+              "path": "photos/winter/january/snowboard.jpg",
               "name": "snowboard.jpg",
               "size": 100,
-              "type": "file"
             }
           ]
         }
@@ -80,19 +93,6 @@ To:
 }
 ```
 
-##Usage
-
-```javascript
-var dirTree = require('directory-tree');
-var tree = dirTree.directoryTree('/some/path');
-```
-
-And you can also filter by extensions:
-
-```javascript
-var dirTree = require('directory-tree');
-var filteredTree = dirTree.directoryTree('/some/path', ['.jpg', '.png']);
-```
 
 
 ## Dev
@@ -100,7 +100,7 @@ var filteredTree = dirTree.directoryTree('/some/path', ['.jpg', '.png']);
 To run tests go the package root in your CLI and run,
 
 ```bash
-$ mocha
+$ npm test
 ```
 
 Make sure you have the dev dependcies installed (e.g. `npm install .`)

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -2,9 +2,12 @@ const FS = require('fs');
 const PATH = require('path');
 
 function directoryTree (path, extensions) {
-	const stats = FS.statSync(path);
 	const name = PATH.basename(path);
 	const item = { path, name };
+	let stats;
+
+	try { stats = FS.statSync(path); }
+	catch (e) { return null; }
 
 	if (stats.isFile()) {
 		const ext = PATH.extname(path).toLowerCase();

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const FS = require('fs');
 const PATH = require('path');
 

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -1,54 +1,24 @@
-var fs = require('fs');
-var path = require('path');
+const FS = require('fs');
+const PATH = require('path');
 
-function directoryTree(basepath, extensions) {
-    var _directoryTree = function (name, extensions) {
-        /*
-         * Certain symbolic links/weird files break when you try to stat them
-         */
-        try {
-            var stats = fs.statSync(name);
-        } catch(e) {
-            return null;
-        }
+function directoryTree (path, extensions) {
+	const stats = FS.statSync(path);
+	const name = PATH.basename(path);
+	const item = { path, name };
 
-        var item = {
-            path: path.relative(basepath, name),
-            name: path.basename(name)
-        };
-
-        if (stats.isFile()) {
-            if (extensions &&
-                extensions.length > 0 &&
-                extensions.indexOf(path.extname(name).toLowerCase()) == -1 &&
-                extensions.indexOf(path.basename(name)) > -1) {
-                return null;
-            }
-            item.type = 'file';
-            item.size = stats.size;  // File size in bytes
-        } else if(stats.isDirectory()) {
-            item.type = 'directory';
-            item.children = fs.readdirSync(name).map(function (child) {
-                return _directoryTree(path.join(name, child), extensions);
-            }).filter(function (e) {
-                return e != null;
-            });
-
-            if (item.children.length == 0) {
-                return null;
-            } else { // The dir has files inside of it, sum up their size
-                item.size = item.children.reduce(function(previous, current) {
-                    return previous + current.size;
-                }, 0);
-            }
-        } else {
-            return null;
-        }
-
-        return item;
-    }
-    return _directoryTree(basepath, extensions);
+	if (stats.isFile()) {
+		const ext = PATH.extname(path).toLowerCase();
+		if (extensions && extensions.length && extensions.indexOf(ext) === -1) return null;
+		item.size = stats.size;  // File size in bytes
+	}
+	else {
+		item.children = FS.readdirSync(path)
+			.map(child => directoryTree(PATH.join(path, child), extensions))
+			.filter(e => !!e);
+		if (!item.children.length) return null;
+		item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
+	}
+	return item;
 }
 
-exports.directoryTree = directoryTree;
-
+module.exports = directoryTree;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directory-tree",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Convert a directory tree to a JS object.",
   "repository": {
     "type": "git",
@@ -23,6 +23,6 @@
     "mocha": "^2.2.5"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "mocha"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const expect = require('chai').expect;
 const dirtree = require('../lib/directory-tree');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,20 +1,22 @@
-var expect = require('chai').expect;
-var dirtree = require('../lib/directory-tree');
+const expect = require('chai').expect;
+const dirtree = require('../lib/directory-tree');
 
 
-describe('directoryTree', function() {
-  it('should return an Object', function() {
-    var tree = dirtree.directoryTree('./test/test_data', ['.DS_Store', '.gitkeep']);
-    expect(tree).to.be.an('object');
-  });
+describe('directoryTree', () => {
 
-  it('should list the children in a directory', function() {
-    var tree = dirtree.directoryTree('./test/test_data', ['.DS_Store', '.gitkeep']);
-    expect(tree.children.length).to.equal(3);
-  });
+	it('should return an Object', () => {
+		const tree = dirtree('./test/test_data', ['.txt']);
+		expect(tree).to.be.an('object');
+	});
 
-  it('should display the size of a directory (summing up the children)', function() {
-    var tree = dirtree.directoryTree('./test/test_data', ['.DS_Store', '.gitkeep']);
-    expect(tree.size).to.equal(11304);
-  });
+	it('should list the children in a directory', () => {
+		const tree = dirtree('./test/test_data', ['.txt']);
+		expect(tree.children.length).to.equal(3);
+	});
+
+	it('should display the size of a directory (summing up the children)', () => {
+		const tree = dirtree('./test/test_data', ['.txt']);
+		expect(tree.size).to.be.above(11000);
+	});
+
 });


### PR DESCRIPTION
- simplify code
- es6 syntax
- return full path instead of relative (IMO this was a bug, as the relative path is useless, cannot get file info in a nice reactive way, etc.)
- remove `item.type` as it's redundant information (`item.type = (item.children ? 'directory' : 'file')`)
- Update .travis.yml to use node 4.2 (drop legacy node versions)
- update readme
