### PR TITLE
Catch EACCES exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ And return a js object:
 ## Note
 Device, FIFO and socket files are ignored.
 
+Files to which the user does not have permissions are included in the directory
+tree, however, directories to which the user does not have permissions, along
+with all of its contained files, are completely ignored.
+
 ## Dev
 
 To run tests go the package root in your CLI and run,
@@ -112,4 +116,3 @@ Make sure you have the dev dependcies installed (e.g. `npm install .`)
 ## Node version
 
 Check out version `0.1.1` if you need support for older versions of node.
-

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -18,11 +18,17 @@ function directoryTree (path, extensions) {
 		item.extension = ext;
 	}
 	else if (stats.isDirectory()) {
-		item.children = FS.readdirSync(path)
-			.map(child => directoryTree(PATH.join(path, child), extensions))
-			.filter(e => !!e);
-		if (!item.children.length) return null;
-		item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
+		try {
+			item.children = FS.readdirSync(path)
+				.map(child => directoryTree(PATH.join(path, child), extensions))
+				.filter(e => !!e);
+			if (!item.children.length) return null;
+			item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
+		} catch(ex) {
+			if (ex.code == "EACCES")
+				//User does not have permissions, ignore directory
+				return null;
+		}
 	} else {
 		return null; // Or set item.size = 0 for devices, FIFO and sockets ?
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -21,4 +21,8 @@ describe('directoryTree', () => {
 		expect(tree.size).to.be.above(11000);
 	});
 
+	it('should not crash with directories where the user does not have necessary permissions', () => {
+		const tree = dirtree('/root/', ['.txt']);
+		expect(tree).to.equal(null);
+	});
 });


### PR DESCRIPTION
I was trying to scan all the video files in my computer with an express server when I noticed that `directoryTree` threw a EACCES exception with directories that belonged to root and I did not have permissions to read. This made my whole server crash. I fixed it with a try - catch block. I was looking through the node API docs for a more elegant solution, but I couldn't find anything better. If you know a better workaround please let me know. 

The function returns null when an EACCES exception is caught. It sounds a bit problematic, but the current behavior of the function is to return null if the directory is empty, so I decided to go with that.  So far it works great for me. I even added a test case for this.