### PR TITLE
Added a callback function to execute on each matching file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var tree = dirtree('./test/test_data', ['.jpg'], function(item, PATH) {
 });
 ```
 
-The callback function takes the directory item (has path, name, size, and extension) and an instance of node path https://nodejs.org/api/path.html
+The callback function takes the directory item (has path, name, size, and extension) and an instance of [node path](https://nodejs.org/api/path.html)
 
 ##Result
 Given a directory structured like this:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,18 @@ var dirTree = require('directory-tree');
 var filteredTree = dirTree('/some/path', ['.jpg', '.png']);
 ```
 
-This will take a directory tree:
+A callback function can be executed with each file that matches the extensions provided:
+```js
+var dirTree = require('directory-tree');
+var tree = dirtree('./test/test_data', ['.jpg'], function(item, PATH) {
+	console.log(item);
+});
+```
+
+The callback function takes the directory item (has path, name, size, and extension) and an instance of node path https://nodejs.org/api/path.html
+
+##Result
+Given a directory structured like this:
 
 ```
 photos
@@ -38,7 +49,7 @@ photos
         └── snowboard.jpg
 ```
 
-And return a js object:
+directory-tree will return this js object:
 
 ```json
 {

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -15,15 +15,14 @@ function directoryTree (path, extensions, onEachFile) {
 		const ext = PATH.extname(path).toLowerCase();
 
 		// Only add files with the provided extensions
-		if (extensions && extensions.length && extensions.indexOf(ext) === -1) {
+		if (extensions && extensions.length && extensions.indexOf(ext) === -1)
 			return null;
-		} else {
-			item.size = stats.size;  // File size in bytes
-			item.extension = ext;
+			
+		item.size = stats.size;  // File size in bytes
+		item.extension = ext;
 
-			if (onEachFile) {
-				onEachFile(item, PATH);
-			}
+		if (onEachFile) {
+			onEachFile(item, PATH);
 		}
 	}
 	else if (stats.isDirectory()) {

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -3,7 +3,7 @@
 const FS = require('fs');
 const PATH = require('path');
 
-function directoryTree (path, extensions) {
+function directoryTree (path, extensions, onEachFile) {
 	const name = PATH.basename(path);
 	const item = { path, name };
 	let stats;
@@ -13,14 +13,23 @@ function directoryTree (path, extensions) {
 
 	if (stats.isFile()) {
 		const ext = PATH.extname(path).toLowerCase();
-		if (extensions && extensions.length && extensions.indexOf(ext) === -1) return null;
-		item.size = stats.size;  // File size in bytes
-		item.extension = ext;
+
+		// Only add files with the provided extensions
+		if (extensions && extensions.length && extensions.indexOf(ext) === -1) {
+			return null;
+		} else {
+			item.size = stats.size;  // File size in bytes
+			item.extension = ext;
+
+			if (onEachFile) {
+				onEachFile(item, PATH);
+			}
+		}
 	}
 	else if (stats.isDirectory()) {
 		try {
 			item.children = FS.readdirSync(path)
-				.map(child => directoryTree(PATH.join(path, child), extensions))
+				.map(child => directoryTree(PATH.join(path, child), extensions, onEachFile))
 				.filter(e => !!e);
 			if (!item.children.length) return null;
 			item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,28 @@ describe('directoryTree', () => {
 		expect(tree.children.length).to.equal(3);
 	});
 
+	it('should execute a callback function for each file with no specified extensions', () => {
+		let number_of_files =  7;
+		let callback_executed_times = 0;
+
+		const tree = dirtree('./test/test_data', null, function(item, PATH) {
+			callback_executed_times++;
+		});
+
+		expect(callback_executed_times).to.equal(number_of_files);
+	});
+
+	it('should execute a callback function for each file with a specified extension', () => {
+		let number_of_files =  6;
+		let callback_executed_times = 0;
+
+		const tree = dirtree('./test/test_data', ['.txt'], function(item, PATH) {
+			callback_executed_times++;
+		});
+
+		expect(callback_executed_times).to.equal(number_of_files);
+	});
+
 	it('should display the size of a directory (summing up the children)', () => {
 		const tree = dirtree('./test/test_data', ['.txt']);
 		expect(tree.size).to.be.above(11000);


### PR DESCRIPTION
Callback function executes for each file that matches the requested extension.  Takes the item and the PATH instance as arguments.  Updated documentation and added test cases.
