### PR TITLE
Don't swallow exceptions thrown in callbacks

### DIFF
--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -3,6 +3,19 @@
 const FS = require('fs');
 const PATH = require('path');
 
+function safeReadDirSync (path) {
+	let dirData = {};
+	try {
+		dirData = FS.readdirSync(path);
+	} catch(ex) {
+		if (ex.code == "EACCES")
+			//User does not have permissions, ignore directory
+			return null;
+		else throw ex;
+	}
+	return dirData;
+}
+
 function directoryTree (path, options, onEachFile) {
 	const name = PATH.basename(path);
 	const item = { path, name };
@@ -27,16 +40,12 @@ function directoryTree (path, options, onEachFile) {
 		}
 	}
 	else if (stats.isDirectory()) {
-		try {
-			item.children = FS.readdirSync(path)
-				.map(child => directoryTree(PATH.join(path, child), options, onEachFile))
-				.filter(e => !!e);
-			item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
-		} catch(ex) {
-			if (ex.code == "EACCES")
-				//User does not have permissions, ignore directory
-				return null;
-		}
+		let dirData = safeReadDirSync(path);
+		if (dirData === null) return null;
+		item.children = dirData
+			.map(child => directoryTree(PATH.join(path, child), options, onEachFile))
+			.filter(e => !!e);
+		item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
 	} else {
 		return null; // Or set item.size = 0 for devices, FIFO and sockets ?
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -55,4 +55,14 @@ describe('directoryTree', () => {
 		const tree = dirtree('./test/test_data');
 		expect(tree).to.deep.equal(testTree);
 	});
+
+	it('should not swallow exceptions thrown in the callback function', () => {
+		const error = new Error('Something happened!');
+		const badFunction = function () {
+			dirtree('./test/test_data', {extensions:['.txt']}, function(item) {
+			  throw error;
+			});
+		}
+		expect(badFunction).to.throw(error);
+	})
 });


### PR DESCRIPTION
Do not execute callback function inside try catch block because it will
swallow the exception. New function safeReadDirSync only catches the
EACCES exception thrown by readdirSync.

I am using node-directory-tree to test a directory full of json files with jest. I want to make sure that they all have valid syntax and other properties. I do all my assertions inside the callback function. There I found a bug in which my assertion errors were not being reported by the test runner because of a try catch block swallowing them inside directory-tree.js. This PR fixes it and adds a test case.