### PR TITLE
added an item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,25 @@ photos
   "path": "photos",
   "name": "photos",
   "size": 600,
+  "type": "directory",
   "children": [
     {
       "path": "photos/summer",
       "name": "summer",
       "size": 400,
+      "type": "directory",
       "children": [
         {
           "path": "photos/summer/june",
           "name": "june",
           "size": 400,
+          "type": "directory",
           "children": [
             {
               "path": "photos/summer/june/windsurf.jpg",
               "name": "windsurf.jpg",
               "size": 400,
+              "type": "file",
               "extension": ".jpg"
             }
           ]
@@ -82,22 +86,26 @@ photos
       "path": "photos/winter",
       "name": "winter",
       "size": 200,
+      "type": "directory",
       "children": [
         {
           "path": "photos/winter/january",
           "name": "january",
           "size": 200,
+          "type": "directory",
           "children": [
             {
               "path": "photos/winter/january/ski.png",
               "name": "ski.png",
               "size": 100,
+              "type": "file",
               "extension": ".png"
             },
             {
               "path": "photos/winter/january/snowboard.jpg",
               "name": "snowboard.jpg",
               "size": 100,
+              "type": "file",
               "extension": ".jpg"
             }
           ]

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -2,6 +2,10 @@
 
 const FS = require('fs');
 const PATH = require('path');
+const constants = {
+	DIRECTORY: 'directory',
+	FILE: 'file'
+}
 
 function directoryTree (path, options, onEachFile) {
 	const name = PATH.basename(path);
@@ -19,9 +23,10 @@ function directoryTree (path, options, onEachFile) {
 			options.extensions.length && 
 			options.extensions.indexOf(ext) === -1)
 			return null;
-			
+
 		item.size = stats.size;  // File size in bytes
 		item.extension = ext;
+		item.type = constants.FILE;
 		if (onEachFile) {
 			onEachFile(item, PATH);
 		}
@@ -32,6 +37,7 @@ function directoryTree (path, options, onEachFile) {
 				.map(child => directoryTree(PATH.join(path, child), options, onEachFile))
 				.filter(e => !!e);
 			item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
+			item.type = constants.DIRECTORY;
 		} catch(ex) {
 			if (ex.code == "EACCES")
 				//User does not have permissions, ignore directory
@@ -43,4 +49,4 @@ function directoryTree (path, options, onEachFile) {
 	return item;
 }
 
-module.exports = directoryTree;
+module.exports = directoryTree

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -58,4 +58,4 @@ function directoryTree (path, options, onEachFile) {
 	return item;
 }
 
-module.exports = directoryTree
+module.exports = directoryTree;

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,37 +1,44 @@
 tree = {
   "path": "./test/test_data",
   "name": "test_data",
+  "type": "directory",
   "children": [
     {
       "path": "test/test_data/file_a.txt",
       "name": "file_a.txt",
       "size": 12,
+      "type": "file",
       "extension": ".txt"
     },
     {
       "path": "test/test_data/file_b.txt",
       "name": "file_b.txt",
       "size": 3756,
+      "type": "file",
       "extension": ".txt"
     },
     {
       "path": "test/test_data/some_dir",
       "name": "some_dir",
+      "type": "directory",
       "children": [
         {
           "path": "test/test_data/some_dir/another_dir",
           "name": "another_dir",
+          "type": "directory",
           "children": [
             {
               "path": "test/test_data/some_dir/another_dir/file_a.txt",
               "name": "file_a.txt",
               "size": 12,
+              "type": "file",
               "extension": ".txt"
             },
             {
               "path": "test/test_data/some_dir/another_dir/file_b.txt",
               "name": "file_b.txt",
               "size": 3756,
+              "type": "file",
               "extension": ".txt"
             }
           ],
@@ -41,12 +48,14 @@ tree = {
           "path": "test/test_data/some_dir/file_a.txt",
           "name": "file_a.txt",
           "size": 12,
+          "type": "file",
           "extension": ".txt"
         },
         {
           "path": "test/test_data/some_dir/file_b.txt",
           "name": "file_b.txt",
           "size": 3756,
+          "type": "file",
           "extension": ".txt"
         }
       ],
@@ -55,11 +64,13 @@ tree = {
     {
       "path": "test/test_data/some_dir_2",
       "name": "some_dir_2",
+      "type": "directory",
       "children": [
         {
           "path": "test/test_data/some_dir_2/.gitkeep",
           "name": ".gitkeep",
           "size": 0,
+          "type": "file",
           "extension": ""
         }
       ],


### PR DESCRIPTION
I created constants but unfortunately I cannot export them because we need to keep the compatibility with the actual implementation

```js
const dirTree = require('directory-tree');
```

When Node will natively support ES6 import, it can be interesting to do

*in lib/directory-tree.js*
```js
export constants
export default directoryTree
```

```js
import directoryTree, { constants } from 'directory-tree'
```

Closing issue #26 