### PR TITLE
 Allow an array of RegExp as option for directory exclusion test

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ const tree = dirTree('./test/test_data', {extensions:/\.txt$/}, (item, PATH) => 
 
 The callback function takes the directory item (has path, name, size, and extension) and an instance of [node path](https://nodejs.org/api/path.html).
 
+## Options
+
+`exclude` : `RegExp|RegExp[]` - A RegExp or an array of RegExp to test for exlusion of directories.
+`extensions` : `RegExp` - A RegExp to test for exclusion of files with the matching extension.
+`normalizePath` : `Boolean` - If true, windows style paths will be normalized to unix style pathes (/ instead of \\).
+
 ## Result
 Given a directory structured like this:
 

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -20,8 +20,27 @@ function safeReadDirSync (path) {
 	return dirData;
 }
 
+/**
+ * Normalizes windows style paths by replacing double backslahes with single forward slahes (unix style).
+ * @param  {string} path
+ * @return {string}
+ */
+function normalizePath(path) {
+	return path.replace(/\\/g, '/');
+}
+
+/**
+ * Tests if the supplied parameter is of type RegExp
+ * @param  {any}  regExp
+ * @return {Boolean}
+ */
+function isRegExp(regExp) {
+	return typeof regExp === "object" && regExp.constructor == RegExp;
+}
+
 function directoryTree (path, options, onEachFile) {
 	const name = PATH.basename(path);
+	path = options && options.normalizePath ? normalizePath(path) : path;
 	const item = { path, name };
 	let stats;
 
@@ -29,8 +48,12 @@ function directoryTree (path, options, onEachFile) {
 	catch (e) { return null; }
 
 	// Skip if it matches the exclude regex
-	if (options && options.exclude && options.exclude.test(path))
-		return null;  
+	if (options && options.exclude) {
+		const excludes =  isRegExp(options.exclude) ? [options.exclude] : options.exclude;
+		if (excludes.some((exclusion) => exclusion.test(path))) {
+			return null;
+		}
+	}
 
 	if (stats.isFile()) {
 		

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directory-tree",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Convert a directory tree to a JS object.",
   "repository": {
     "type": "git",

--- a/test/fixtureMultipleExclude.js
+++ b/test/fixtureMultipleExclude.js
@@ -1,0 +1,46 @@
+tree = {
+  "path": "./test/test_data",
+  "name": "test_data",
+  "children": [
+    {
+      "path": "test/test_data/file_a.txt",
+      "name": "file_a.txt",
+      "size": 12,
+      "extension": ".txt",
+      "type": "file"
+    },
+    {
+      "path": "test/test_data/file_b.txt",
+      "name": "file_b.txt",
+      "size": 3756,
+      "extension": ".txt",
+      "type": "file"
+    },
+    {
+      "path": "test/test_data/some_dir",
+      "name": "some_dir",
+      "children": [
+        {
+          "path": "test/test_data/some_dir/file_a.txt",
+          "name": "file_a.txt",
+          "size": 12,
+          "extension": ".txt",
+          "type": "file"
+        },
+        {
+          "path": "test/test_data/some_dir/file_b.txt",
+          "name": "file_b.txt",
+          "size": 3756,
+          "extension": ".txt",
+          "type": "file"
+        }
+      ],
+      "type": "directory",
+      "size": 3768
+    }
+  ],
+  "size": 7536,
+  "type": "directory"
+}
+
+module.exports = tree;

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const dirtree = require('../lib/directory-tree');
 const testTree = require('./fixture.js');
 const excludeTree =  require('./fixtureExclude.js')
+const excludeTree2 =  require('./fixtureMultipleExclude.js')
 
 
 describe('directoryTree', () => {
@@ -52,7 +53,7 @@ describe('directoryTree', () => {
 	});
 
 	it('should return the correct exact result', () => {
-		const tree = dirtree('./test/test_data');
+		const tree = dirtree('./test/test_data', {normalizePath: true});
 		expect(tree).to.deep.equal(testTree);
 	});
 
@@ -67,7 +68,12 @@ describe('directoryTree', () => {
 	})
 
 	it('should exclude the correct folders', () => {
-		const tree = dirtree('./test/test_data',{exclude: /another_dir/});
+		const tree = dirtree('./test/test_data',{exclude: /another_dir/, normalizePath: true});
 		expect(tree).to.deep.equal(excludeTree);
+	});
+
+	it('should exclude multiple folders', () => {
+		const tree = dirtree('./test/test_data', {exclude: [/another_dir/, /some_dir_2/], normalizePath: true});
+		expect(tree).to.deep.equal(excludeTree2);
 	});
 });


### PR DESCRIPTION
See #38

Also added optional normalize Path option to mitigate file path differences between windows and unix-style systems (tests did not work on windows...)