### PR TITLE
[Bug] Fix typescript export to align with implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,4 +17,4 @@ export declare class DirectoryTree {
   extension?: string;
 }
 
-export default directoryTree;
+export = directoryTree;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare const directoryTree: (
   onEachFile?: (item: DirectoryTree, path: string) => void
 ) => DirectoryTree;
 
-export declare class DirectoryTree {
+declare class DirectoryTree {
   path: string;
   name: string;
   size: number;


### PR DESCRIPTION
The existing type declarations do not align with the implementation, in terms of exports.

In the CJS world, this library is consumed like
```ts
const dirTree = require("directory-tree");
```
which is understandable, given the way the main function is exported
https://github.com/mihneadb/node-directory-tree/blob/fe19620116e9b877c3d87f08227adc1230f1b18a/lib/directory-tree.js#L88


The proper way to express this in typescript is
```ts
export = dirTree
```
and consume it as 

```ts
import * as dirTree from 'directory-tree'
```