### PR TITLE
improve typescript declare file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,54 +1,58 @@
-declare const directoryTree: (
-  path: string,
-  options?: {
-    normalizePath?: boolean;
-    exclude?: RegExp | RegExp[];
-    attributes?: string[];
-    extensions?: RegExp;
-  },
-  onEachFile?: (item: DirectoryTree, path: string, stats: Stats) => void,
-  onEachDirectory?: (item: DirectoryTree, path: string, stats: Stats) => void,
-) => DirectoryTree;
+declare function directoryTree(
+    path: string,
+    options?: {
+        normalizePath?: boolean;
+        exclude?: RegExp | RegExp[];
+        attributes?: string[];
+        extensions?: RegExp;
+    },
+    onEachFile?: (item: DirectoryTree.DirectoryTree, path: string, stats: DirectoryTree.Stats) => void,
+    onEachDirectory?: (item: DirectoryTree.DirectoryTree, path: string, stats: DirectoryTree.Stats) => void,
+): DirectoryTree.DirectoryTree;
 
-declare class DirectoryTree {
-  path: string;
-  name: string;
-  size: number;
-  type: "directory" | "file";
-  children?: DirectoryTree[];
-  extension?: string;
-}
+export as namespace DirectoryTree
 
-/*
- * Node.js fs.Stats from
- * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/fbe90f14d5f6b6d65c4aa78284f212c736078d19/types/node/index.d.ts#L3696
-*/
-declare class Stats {
-  isFile(): boolean;
-  isDirectory(): boolean;
-  isBlockDevice(): boolean;
-  isCharacterDevice(): boolean;
-  isSymbolicLink(): boolean;
-  isFIFO(): boolean;
-  isSocket(): boolean;
-  dev: number;
-  ino: number;
-  mode: number;
-  nlink: number;
-  uid: number;
-  gid: number;
-  rdev: number;
-  size: number;
-  blksize: number;
-  blocks: number;
-  atimeMs: number;
-  mtimeMs: number;
-  ctimeMs: number;
-  birthtimeMs: number;
-  atime: Date;
-  mtime: Date;
-  ctime: Date;
-  birthtime: Date;
+declare namespace DirectoryTree {
+    export class DirectoryTree {
+        path: string;
+        name: string;
+        size: number;
+        type: "directory" | "file";
+        children?: DirectoryTree[];
+        extension?: string;
+    }
+
+    /*
+     * Node.js fs.Stats from
+     * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/fbe90f14d5f6b6d65c4aa78284f212c736078d19/types/node/index.d.ts#L3696
+    */
+    export class Stats {
+        isFile(): boolean;
+        isDirectory(): boolean;
+        isBlockDevice(): boolean;
+        isCharacterDevice(): boolean;
+        isSymbolicLink(): boolean;
+        isFIFO(): boolean;
+        isSocket(): boolean;
+        dev: number;
+        ino: number;
+        mode: number;
+        nlink: number;
+        uid: number;
+        gid: number;
+        rdev: number;
+        size: number;
+        blksize: number;
+        blocks: number;
+        atimeMs: number;
+        mtimeMs: number;
+        ctimeMs: number;
+        birthtimeMs: number;
+        atime: Date;
+        mtime: Date;
+        ctime: Date;
+        birthtime: Date;
+    }
 }
 
 export = directoryTree;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,13 +6,13 @@ declare function directoryTree(
         attributes?: string[];
         extensions?: RegExp;
     },
-    onEachFile?: (item: DirectoryTree.DirectoryTree, path: string, stats: DirectoryTree.Stats) => void,
-    onEachDirectory?: (item: DirectoryTree.DirectoryTree, path: string, stats: DirectoryTree.Stats) => void,
-): DirectoryTree.DirectoryTree;
+    onEachFile?: (item: directoryTree.DirectoryTree, path: string, stats: directoryTree.Stats) => void,
+    onEachDirectory?: (item: directoryTree.DirectoryTree, path: string, stats: directoryTree.Stats) => void,
+): directoryTree.DirectoryTree;
 
 export as namespace directoryTree
 
-declare namespace directoryTree {
+declare namespace DirectoryTree {
     export class DirectoryTree {
         path: string;
         name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,9 @@ declare function directoryTree(
     onEachDirectory?: (item: DirectoryTree.DirectoryTree, path: string, stats: DirectoryTree.Stats) => void,
 ): DirectoryTree.DirectoryTree;
 
-export as namespace DirectoryTree
+export as namespace directoryTree
 
-declare namespace DirectoryTree {
+declare namespace directoryTree {
     export class DirectoryTree {
         path: string;
         name: string;


### PR DESCRIPTION
The module was almost impossible to properly use in a TypeScript project as far as i was able to figure out as the DirectoryTree and Stats classes weren't able to be used in any files where the module got imported. This fixed that so you can actually statically type accordingly in TS projects.