### PR TITLE
Changed attribute option to use Stats object keys as string type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare function directoryTree(
     options?: {
         normalizePath?: boolean;
         exclude?: RegExp | RegExp[];
-        attributes?: string[];
+        attributes?: (keyof directoryTree.Stats)[];
         extensions?: RegExp;
     },
     onEachFile?: (item: directoryTree.DirectoryTree, path: string, stats: directoryTree.Stats) => void,


### PR DESCRIPTION
I saw that you just provide an arbitrary string array type to the attributes option, and since you can only provide those I thought it would be good to reflect that in the type definitions. 😄 