### PR TITLE
Fix for Node Path instance not being sent to onEachFile and onEachDirectory callbacks

### DIFF
--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -84,7 +84,7 @@ function directoryTree (path, options, onEachFile, onEachDirectory) {
 		}
 
 		if (onEachFile) {
-			onEachFile(item, path, stats);
+			onEachFile(item, PATH, stats);
 		}
 	}
 	else if (stats.isDirectory()) {
@@ -102,7 +102,7 @@ function directoryTree (path, options, onEachFile, onEachDirectory) {
 		item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
 		item.type = constants.DIRECTORY;
 		if (onEachDirectory) {
-			onEachDirectory(item, path, stats);
+			onEachDirectory(item, PATH, stats);
 		}
 	} else {
 		return null; // Or set item.size = 0 for devices, FIFO and sockets ?


### PR DESCRIPTION
The README says: "The callback function takes the directory item (has path, name, size, and extension) and an instance of [node path](https://nodejs.org/api/path.html) and an instance of [node FS.stats](https://nodejs.org/api/fs.html#fs_class_fs_stats)."

However, the callbacks are not sent the Node Path instance but instead are sent the `path` variable.

Changing from `path` to `PATH` fixes it to work as described in the README.