### PR TITLE
Default attributes only "name", "path" and "children"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -80,7 +80,7 @@ function directoryTree (path, options, onEachFile, onEachDirectory) {
       options = { ...options, symlinks: [] };
     // Skip if a cyclic symbolic link has been found
     if (options.symlinks.find(ino => ino === lstat.ino)) {
-      return null; 
+      return null;
     } else {
       options.symlinks.push(lstat.ino);
     }
@@ -94,13 +94,20 @@ function directoryTree (path, options, onEachFile, onEachDirectory) {
     if (options.extensions && !options.extensions.test(ext))
       return null;
 
-    item.size = stats.size;  // File size in bytes
-    item.extension = ext;
-    item.type = constants.FILE;
 
     if (options.attributes) {
       options.attributes.forEach((attribute) => {
-        item[attribute] = stats[attribute];
+        switch (attribute) {
+          case 'extension':
+            item.extension = ext;
+            break;
+          case 'type':
+            item.type = constants.FILE;
+            break;
+          default:
+            item[attribute] = stats[attribute];
+            break;
+        }
       });
     }
 
@@ -112,16 +119,27 @@ function directoryTree (path, options, onEachFile, onEachDirectory) {
     let dirData = safeReadDirSync(path);
     if (dirData === null) return null;
 
-    if (options.attributes) {
-      options.attributes.forEach((attribute) => {
-        item[attribute] = stats[attribute];
-      });
-    }
     item.children = dirData
       .map(child => directoryTree(PATH.join(path, child), options, onEachFile, onEachDirectory))
       .filter(e => !!e);
-    item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
-    item.type = constants.DIRECTORY;
+
+    if (options.attributes) {
+      options.attributes.forEach((attribute) => {
+        switch (attribute) {
+          case 'size':
+            item.size = item.children.reduce((prev, cur) => prev + cur.size, 0);
+            break;
+          case 'type':
+            item.type = constants.DIRECTORY;
+            break;
+          default:
+            item[attribute] = stats[attribute];
+            break;
+        }
+        
+      });
+    }
+
     if (onEachDirectory) {
       onEachDirectory(item, path, stats);
     }

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -132,6 +132,8 @@ function directoryTree (path, options, onEachFile, onEachDirectory) {
           case 'type':
             item.type = constants.DIRECTORY;
             break;
+          case 'extension':
+            break;
           default:
             item[attribute] = stats[attribute];
             break;

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,7 @@ describe('directoryTree', () => {
   });
 
   it('should display the size of a directory (summing up the children)', () => {
-    const tree = dirtree('./test/test_data', {extensions:/\.txt$/});
+    const tree = dirtree('./test/test_data', {extensions:/\.txt$/, attributes: ['size']});
     expect(tree.size).to.be.above(11000);
   });
 
@@ -65,7 +65,7 @@ describe('directoryTree', () => {
   });
 
   it('should return the correct exact result', () => {
-    const tree = dirtree('./test/test_data', {normalizePath: true, followSymlinks: false });
+    const tree = dirtree('./test/test_data', {normalizePath: true, followSymlinks: false, attributes: ['size','type','extension'] });
     expect(tree).to.deep.equal(testTree);
   });
 
@@ -80,12 +80,12 @@ describe('directoryTree', () => {
   })
 
   it('should exclude the correct folders', () => {
-    const tree = dirtree('./test/test_data',{exclude: /another_dir/, normalizePath: true, followSymlinks: false});
+    const tree = dirtree('./test/test_data',{exclude: /another_dir/, normalizePath: true, followSymlinks: false, attributes: ['size','type','extension']});
     expect(tree).to.deep.equal(excludeTree);
   });
 
   it('should exclude multiple folders', () => {
-    const tree = dirtree('./test/test_data', {exclude: [/another_dir/, /some_dir_2/], normalizePath: true, followSymlinks: false});
+    const tree = dirtree('./test/test_data', {exclude: [/another_dir/, /some_dir_2/], normalizePath: true, followSymlinks: false, attributes: ['size','type','extension']});
     expect(tree).to.deep.equal(excludeTree2);
 
   });
@@ -101,7 +101,7 @@ describe('directoryTree', () => {
   });
 
   it('should follow symlinks', () => {
-    const tree = dirtree('./test/test_data', {normalizePath: true, followSymlinks: true });
+    const tree = dirtree('./test/test_data', {normalizePath: true, followSymlinks: true, attributes: ['size','type','extension'] });
     expect(tree).to.deep.equal(symlinkTree);
   })
 


### PR DESCRIPTION
I changed the code a little bit to make default attributes only "name", "path" and "children".
[issue thread](https://github.com/mihneadb/node-directory-tree/issues/74)