### PR TITLE
DirectoryTree - Missing custom field support in typescript interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,33 @@ photos
 }
 ```
 
+## Adding custom fields
+You can easily extend a `DirectoryTree` object with custom fields by adding them to the custom field.
+For example add an `id` based on the path of a `DirectoryTree` object for each directory and file like so:
+```
+import { createHash } from 'crypto';
+import * as directoryTree from 'directory-tree';
+import { DirectoryTree, DirectoryTreeOptions, DirectoryTreeCallback } from 'directory-tree';
+
+const callback: DirectoryTreeCallback = (
+            item: DirectoryTree,
+            path: string
+        ) => {
+            item.custom.id = createHash('sha1').update(path).digest('base64');
+        };
+
+const dirTree: DirectoryTree & { id?: string } = directoryTree(
+    "<your-directory-path>",
+    {},
+    callback,
+    callback
+);
+
+// to explore the object with the new custom fields
+console.log(JSON.stringify(dirTree, null, 2));
+
+```
+
 ## Note
 
 Device, FIFO and socket files are ignored.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,37 @@
 import { Stats } from 'fs';
 
 declare function directoryTree(
-  path: string,
-  options ? : directoryTree.DirectoryTreeOptions,
-  onEachFile ? : directoryTree.DirectoryTreeCallback,
-  onEachDirectory ? : directoryTree.DirectoryTreeCallback,
+	path: string,
+	options?: directoryTree.DirectoryTreeOptions,
+	onEachFile?: directoryTree.DirectoryTreeCallback,
+	onEachDirectory?: directoryTree.DirectoryTreeCallback
 ): directoryTree.DirectoryTree;
 
 export as namespace directoryTree;
 
 declare namespace directoryTree {
-  export interface DirectoryTree {
-    path: string;
-    name: string;
-    size: number;
-    type: "directory" | "file";
-    children ? : DirectoryTree[];
-    extension?: string;
-    isSymbolicLink?: boolean;
-    [key: string]: any;
-  }
-  export interface DirectoryTreeOptions {
-    normalizePath ? : boolean;
-    exclude ? : RegExp | RegExp[];
-    attributes ? : (keyof Stats | "type" | "extension")[];
-    extensions ? : RegExp;
-    followSymlink ? : boolean;
-  }
-  export type DirectoryTreeCallback = (item: DirectoryTree, path: string, stats: Stats) => void;
+	export interface DirectoryTree {
+		path: string;
+		name: string;
+		size: number;
+		type: 'directory' | 'file';
+		children?: DirectoryTree[];
+		extension?: string;
+		isSymbolicLink?: boolean;
+		custom: { [key: string]: any };
+	}
+	export interface DirectoryTreeOptions {
+		normalizePath?: boolean;
+		exclude?: RegExp | RegExp[];
+		attributes?: (keyof Stats | 'type' | 'extension')[];
+		extensions?: RegExp;
+		followSymlink?: boolean;
+	}
+	export type DirectoryTreeCallback = (
+		item: DirectoryTree,
+		path: string,
+		stats: Stats
+	) => void;
 }
 
 export = directoryTree;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,33 @@
 import { Stats } from 'fs';
 
 declare function directoryTree(
-	path: string,
-	options?: directoryTree.DirectoryTreeOptions,
-	onEachFile?: directoryTree.DirectoryTreeCallback,
-	onEachDirectory?: directoryTree.DirectoryTreeCallback
+  path: string,
+  options ? : directoryTree.DirectoryTreeOptions,
+  onEachFile ? : directoryTree.DirectoryTreeCallback,
+  onEachDirectory ? : directoryTree.DirectoryTreeCallback,
 ): directoryTree.DirectoryTree;
 
 export as namespace directoryTree;
 
 declare namespace directoryTree {
-	export interface DirectoryTree {
-		path: string;
-		name: string;
-		size: number;
-		type: 'directory' | 'file';
-		children?: DirectoryTree[];
-		extension?: string;
-		isSymbolicLink?: boolean;
-		custom: { [key: string]: any };
-	}
-	export interface DirectoryTreeOptions {
-		normalizePath?: boolean;
-		exclude?: RegExp | RegExp[];
-		attributes?: (keyof Stats | 'type' | 'extension')[];
-		extensions?: RegExp;
-		followSymlink?: boolean;
-	}
-	export type DirectoryTreeCallback = (
-		item: DirectoryTree,
-		path: string,
-		stats: Stats
-	) => void;
+  export interface DirectoryTree {
+    path: string;
+    name: string;
+    size: number;
+    type: "directory" | "file";
+    children ? : DirectoryTree[];
+    extension?: string;
+    isSymbolicLink?: boolean;
+    custom: { [key: string]: any };
+  }
+  export interface DirectoryTreeOptions {
+    normalizePath ? : boolean;
+    exclude ? : RegExp | RegExp[];
+    attributes ? : (keyof Stats | "type" | "extension")[];
+    extensions ? : RegExp;
+    followSymlink ? : boolean;
+  }
+  export type DirectoryTreeCallback = (item: DirectoryTree, path: string, stats: Stats) => void;
 }
 
 export = directoryTree;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,33 @@
 import { Stats } from 'fs';
 
 declare function directoryTree(
-	path: string,
-	options?: directoryTree.DirectoryTreeOptions,
-	onEachFile?: directoryTree.DirectoryTreeCallback,
-	onEachDirectory?: directoryTree.DirectoryTreeCallback
+  path: string,
+  options ? : directoryTree.DirectoryTreeOptions,
+  onEachFile ? : directoryTree.DirectoryTreeCallback,
+  onEachDirectory ? : directoryTree.DirectoryTreeCallback,
 ): directoryTree.DirectoryTree;
 
 export as namespace directoryTree;
 
 declare namespace directoryTree {
-	export interface DirectoryTree {
-		path: string;
-		name: string;
-		size: number;
-		type: 'directory' | 'file';
-		children?: DirectoryTree[];
-		extension?: string;
-		isSymbolicLink?: boolean;
-		[key: string]: any;
-	}
-	export interface DirectoryTreeOptions {
-		normalizePath?: boolean;
-		exclude?: RegExp | RegExp[];
-		attributes?: (keyof Stats | 'type' | 'extension')[];
-		extensions?: RegExp;
-		followSymlink?: boolean;
-	}
-	export type DirectoryTreeCallback = (
-		item: DirectoryTree,
-		path: string,
-		stats: Stats
-	) => void;
+  export interface DirectoryTree {
+    path: string;
+    name: string;
+    size: number;
+    type: "directory" | "file";
+    children ? : DirectoryTree[];
+    extension?: string;
+    isSymbolicLink?: boolean;
+    [key: string]: any;
+  }
+  export interface DirectoryTreeOptions {
+    normalizePath ? : boolean;
+    exclude ? : RegExp | RegExp[];
+    attributes ? : (keyof Stats | "type" | "extension")[];
+    extensions ? : RegExp;
+    followSymlink ? : boolean;
+  }
+  export type DirectoryTreeCallback = (item: DirectoryTree, path: string, stats: Stats) => void;
 }
 
 export = directoryTree;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,32 +1,37 @@
 import { Stats } from 'fs';
 
 declare function directoryTree(
-  path: string,
-  options ? : directoryTree.DirectoryTreeOptions,
-  onEachFile ? : directoryTree.DirectoryTreeCallback,
-  onEachDirectory ? : directoryTree.DirectoryTreeCallback,
+	path: string,
+	options?: directoryTree.DirectoryTreeOptions,
+	onEachFile?: directoryTree.DirectoryTreeCallback,
+	onEachDirectory?: directoryTree.DirectoryTreeCallback
 ): directoryTree.DirectoryTree;
 
 export as namespace directoryTree;
 
 declare namespace directoryTree {
-  export interface DirectoryTree {
-    path: string;
-    name: string;
-    size: number;
-    type: "directory" | "file";
-    children ? : DirectoryTree[];
-    extension?: string;
-    isSymbolicLink?: boolean;
-  }
-  export interface DirectoryTreeOptions {
-    normalizePath ? : boolean;
-    exclude ? : RegExp | RegExp[];
-    attributes ? : (keyof Stats | "type" | "extension")[];
-    extensions ? : RegExp;
-    followSymlink ? : boolean;
-  }
-  export type DirectoryTreeCallback = (item: DirectoryTree, path: string, stats: Stats) => void;
+	export interface DirectoryTree {
+		path: string;
+		name: string;
+		size: number;
+		type: 'directory' | 'file';
+		children?: DirectoryTree[];
+		extension?: string;
+		isSymbolicLink?: boolean;
+		[key: string]: any;
+	}
+	export interface DirectoryTreeOptions {
+		normalizePath?: boolean;
+		exclude?: RegExp | RegExp[];
+		attributes?: (keyof Stats | 'type' | 'extension')[];
+		extensions?: RegExp;
+		followSymlink?: boolean;
+	}
+	export type DirectoryTreeCallback = (
+		item: DirectoryTree,
+		path: string,
+		stats: Stats
+	) => void;
 }
 
 export = directoryTree;


### PR DESCRIPTION
Hey,
just tried to add custom field to DirectoryTree object in typescript inside a DirectoryTreeCallback. The following error occured:

### Error:
```
error TS7053: Element implicitly has an 'any' type because expression of type '"id"' can't be used to index type 'DirectoryTree'.
  Property 'id' does not exist on type 'DirectoryTree'.

34     item['id'] = createHash('sha1').update(path).digest('base64');
```

### Example adding custom id field:
```
import directoryTree, {
    DirectoryTree,
    DirectoryTreeCallback,
} from 'directory-tree';
import { createHash } from 'crypto';

const path = 'C:/Users/me/Desktop/a';
const callback: DirectoryTreeCallback = (item: DirectoryTree, path: string) => {
    item['id'] = createHash('sha1').update(path).digest('base64');
};
const dirTree: DirectoryTree = directoryTree(path, {}, callback, callback);
console.log(JSON.stringify(dirTree, null, 2));
```
### Fix:

Added `[key: string]: any` in to the `DirectoryTree `interface at` node_modules\directory-tree\index.d.ts`.


Already opened an issue here:
https://github.com/mihneadb/node-directory-tree/issues/103

Best
Lukas