### PR TITLE
Fix for using depth option without attributes option set

### DIFF
--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -51,7 +51,7 @@ function isRegExp(regExp) {
 function directoryTree (path, options, onEachFile, onEachDirectory, currentDepth = 0) {
   options = options || {};
 
-  if (options.depth !== undefined && options.attributes.indexOf('size') !== -1) {
+  if (options.depth !== undefined && options.attributes && options.attributes.indexOf('size') !== -1) {
     throw new Error('usage of size attribute with depth option is prohibited');
   }
 


### PR DESCRIPTION
When using depth option without attributes option set, it'll generate errors as below.

```
/home/lingyuncai/work/projects/node-directory-tree/lib/directory-tree.js:54
  if (options.depth !== undefined && options.attributes.indexOf('size') !== -1) {
                                                        ^

TypeError: Cannot read properties of undefined (reading 'indexOf')
    at directoryTree (/home/lingyuncai/work/projects/node-directory-tree/lib/directory-tree.js:54:57)

```

So add an extra check on `options.attributes` to ensure `options.depth` can work properly without `options.attributes` set as below.

```javascript
const tree = directoryTree(
  "/home/lingyuncai/work/projects/demo",
  {
    depth: 1,
  }
);
```