### PR TITLE
filesOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ const tree = dirTree('./test/test_data', {extensions:/\.txt$/}, null, (item, PAT
 
 `depth` : `number` - If presented, reads so many nested dirs as specified in argument. Usage of size attribute with depth option is prohibited.
 
+`filesOnly` : `Boolean` - If true, a flat array containing all matched files will be returned instead of the full directory tree object.
+
 ## Result
 
 Given a directory structured like this:

--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -6,6 +6,7 @@ const constants = {
   DIRECTORY: 'directory',
   FILE: 'file'
 }
+let files = [];
 
 function safeReadDirSync (path) {
   let dirData = {};
@@ -119,6 +120,10 @@ function directoryTree (path, options, onEachFile, onEachDirectory, currentDepth
     if (onEachFile) {
       onEachFile(item, path, stats);
     }
+
+    if (options.filesOnly) {
+      files.push(item);
+    }
   }
   else if (stats.isDirectory()) {
     let dirData = safeReadDirSync(path);
@@ -155,7 +160,11 @@ function directoryTree (path, options, onEachFile, onEachDirectory, currentDepth
   } else {
     return null; // Or set item.size = 0 for devices, FIFO and sockets ?
   }
-  return item;
+  if (options.filesOnly) {
+    return files;
+  } else {
+    return item;
+  }
 }
 
 module.exports = directoryTree;


### PR DESCRIPTION
Added an option to return a flat array containing all matched files & updated the README.md

Let me know if I need to make any changes or if this feature simply isn't wanted 🙂