### PR TITLE
Fixes type error when using strict mode in TS: Type 'TCustomResult' does not satisfy the constraint 'IObj'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ interface IObj {
 declare function directoryTree<
   TCustomFile extends IObj = IObj,
   TCustomDir extends IObj = IObj,
-  TCustomResult = TCustomFile & TCustomDir
+  TCustomResult extends IObj = TCustomFile & TCustomDir
 >(
   path: string,
   options?: directoryTree.DirectoryTreeOptions,


### PR DESCRIPTION
When strict mode is enabled you can get this error:

Fixes the error:
    `node_modules/directory-tree/index.d.ts:16:32 - error TS2344: Type 'TCustomResult' does not satisfy the constraint 'IObj'.`

This is the TSConfig I use to compare.

```json
{
    "compilerOptions": {
        "esModuleInterop": true,
        "target": "es5",
        "moduleResolution": "node",
        "sourceMap": true,
        "outDir": "dist",
        "strict": true,
        "importHelpers": true,
    },
    "lib": ["esnext"],
}
```