### PR TITLE
Fix TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,9 @@
 import { Stats } from "fs";
 
-interface IObj {
-  [key: string]: any;
-}
-
 declare function directoryTree<
-  TCustomFile extends IObj = IObj,
-  TCustomDir extends IObj = IObj,
-  TCustomResult extends IObj = TCustomFile & TCustomDir
+  TCustomFile extends Record<string, any> = Record<string, any>,
+  TCustomDir extends Record<string, any> = Record<string, any>,
+  TCustomResult extends Record<string, any> = TCustomFile & TCustomDir
 >(
   path: string,
   options?: directoryTree.DirectoryTreeOptions,
@@ -18,7 +14,7 @@ declare function directoryTree<
 export as namespace directoryTree;
 
 declare namespace directoryTree {
-  export interface DirectoryTree<C extends IObj = IObj> {
+  export interface DirectoryTree<C extends Record<string, any> = Record<string, any>> {
     path: string;
     name: string;
     size: number;


### PR DESCRIPTION
When exporting some values coming from directory-tree, this TypeScript error is thrown:

```sh
src/example.ts:3:14 - error TS4023: Exported variable 'getTree' has or is using name 'IObj' from external module "/xxxxx/node_modules/.pnpm/directory-tree@3.4.0/node_modules/directory-tree/index" but cannot be named.

3 export const example = () => {
                ~~~~~~~


Found 1 error in src/example.ts:3
```

Code:

```ts
import * as dirTree from 'directory-tree'
// or if `esModuleInterop` is `true`:
// import dirTree from 'directory-tree'

export const example = () => {
  return dirTree('src')
}
```

tsconfig (error happens when emitting declarations):

```json
{
  "compilerOptions": {
    "target": "ES2022",
    "module": "commonjs",
    "declaration": true,
    "outDir": "./dist/"
  },
  "include": ["src/*.ts"],
  "exclude": ["node_modules/**/*", "test/**/*"]
}
```

I replaced the `IObj` type with [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type), which is equivalent but included in TypeScript. It fixes the issue.